### PR TITLE
call close on ready

### DIFF
--- a/src/components/IframeGuard/index.tsx
+++ b/src/components/IframeGuard/index.tsx
@@ -25,6 +25,7 @@ export const IframeGuard: FC<IframeGuardProps> = ({
   useEffect(() => {
     if (!hasMounted.current) {
       parentDispatch(WIDGET_IFRAME_IS_READY_ACTION);
+      close();
       hasMounted.current = true;
     }
   }, [close]);


### PR DESCRIPTION
this was removed in the last change but shouldn't have been - the order of operations is: close event happens first to ensure the widget initializes with the minimized size, and then the open event for the launch on mount stuff happens later.